### PR TITLE
Improve boot time benchmark hack

### DIFF
--- a/benchmark.h
+++ b/benchmark.h
@@ -1,0 +1,13 @@
+#ifndef BENCHMARK_H
+#define BENCHMARK_H
+
+/* IO ports for different exit points */
+#define LINUX_EXIT_PORT 0xf4
+#define FW_EXIT_PORT    0xf5
+
+/* Exit point values */
+#define FW_START    1
+#define LINUX_START_FWCFG 2
+#define LINUX_START_BOOT  3
+
+#endif

--- a/fw_cfg.c
+++ b/fw_cfg.c
@@ -7,6 +7,7 @@
 #include "bswap.h"
 #include "linuxboot.h"
 #include "multiboot.h"
+#include "benchmark.h"
 
 struct fw_cfg_file {
 	uint32_t size;
@@ -174,7 +175,7 @@ static void boot_multiboot_from_fw_cfg(void)
 	/* Exit just before getting to vmlinuz, so that it is easy
 	 * to time/profile the firmware.
 	 */
-	outb(0xf4, 1);
+	outb(LINUX_EXIT_PORT, LINUX_START_FWCFG);
 #endif
 
 	fw_cfg_select(FW_CFG_KERNEL_ENTRY);

--- a/linuxboot.c
+++ b/linuxboot.c
@@ -3,6 +3,7 @@
 #include "ioport.h"
 #include "string.h"
 #include "stdio.h"
+#include "benchmark.h"
 
 static inline uint16_t lduw_p(void *p)
 {
@@ -116,7 +117,7 @@ void boot_bzimage(struct linuxboot_args *args)
 	/* Exit just before getting to vmlinuz, so that it is easy
 	 * to time/profile the firmware.
 	 */
-	outb(0xf4, 1);
+	outb(LINUX_EXIT_PORT, LINUX_START_BOOT);
 #endif
 	asm volatile(
 	    "ljmp $0x18, $pm16_boot_linux - 0xf0000"

--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
 #include "fw_cfg.h"
 #include "pflash.h"
 #include "pci.h"
+#include "benchmark.h"
 
 static void set_realmode_int(int vec, void *p)
 {
@@ -89,6 +90,9 @@ static bool detect_cbfs_and_boot(void)
 
 int __attribute__ ((section (".text.startup"))) main(void)
 {
+#ifdef BENCHMARK_HACK
+       outb(FW_EXIT_PORT, FW_START);
+#endif
 	setup_hw();
 
 	// Now go to the F-segment: we need to move away from flash area


### PR DESCRIPTION
Benchmarking IO port addresses and return values are now defined
    through a dedicated header.
    
Each exit point can have its own IO port address and return value.
    With this we are able to discriminate between similar code paths
    through the QEMU process return values or between different
    code paths by having the QEMU debugexit device monitoring
    different IO port addresses.

We also add one new benchmark point, right at the qboot startup to measure the actual time QEMU takes to handover to the firmware.