### PR TITLE
bug fix for setup_idt

### DIFF
--- a/main.c
+++ b/main.c
@@ -19,7 +19,7 @@ static void set_realmode_int(int vec, void *p)
 static void setup_idt(void)
 {
 	int i;
-	for (i = 0; i < 0x1f; i++)
+	for (i = 0; i < 0x100; i++)
 		set_realmode_int(i, bios_intfake);
 	for (i = 8; i < 16; i++)
 		set_realmode_int(i, bios_irq);


### PR DESCRIPTION
the setup_idt() has not configured default ISR for all interrupt.

CPU lookup IVT and set 0x0:0x0 (cs:ip) as interrupt handler entry
when received an unexpected interrupt which not setup ISR via
set_realmode_int in setup_idt().

howerver, the 0x0:0x0 point to IVT-self and executing it caused
invalid opcode exception, which the interrupt vector is 6, and the
handler bios_intfake not fixing this problem, this makes CPU run
into a infinite loop.