### PR TITLE
Fix initrd base address for PVH boot

### DIFF
--- a/fw_cfg.c
+++ b/fw_cfg.c
@@ -230,7 +230,7 @@ static void boot_pvh_from_fw_cfg(void)
 	fw_cfg_select(FW_CFG_INITRD_SIZE);
 	args.initrd_size = fw_cfg_readl_le();
 	if (args.initrd_size) {
-		fw_cfg_select(FW_CFG_INITRD_SIZE);
+		fw_cfg_select(FW_CFG_INITRD_ADDR);
 		args.initrd_addr = (void *)fw_cfg_readl_le();
 
 		fw_cfg_read_entry(FW_CFG_INITRD_DATA, args.initrd_addr,


### PR DESCRIPTION
Currently if qboot is being used with an ELF/PVH kernel and an externally-supplied initrd the base address for the initrd is wrong leading to low memory being overwritten by the subsequent fw_cfg read for the initrd. This results in a silent boot failure because it generates a fault before any fault handlers are installed and thus triple-faults.