### PR TITLE
qboot: Disable PIE for ELF binary build step

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ c_args = [
 link_args = ['-nostdlib', '-m32']
 link_args += cc.get_supported_link_arguments('-Wl,--build-id=none')
 link_args += '-Wl,-T' + meson.current_source_dir() / 'flat.lds'
+link_args += cc.get_supported_link_arguments(['-no-pie'])
 
 elf = executable(
   'bios.bin.elf',


### PR DESCRIPTION
The switch to meson in commit fd2aada36b98 ("Add meson build") had two major behavior changes for the ELF binary build step:

* ELF binary is no longer build as x86_64 on x86_64
* ELF binary is build as position independent executable on systems with a "--enable-default-pie" gcc

The latter will create a slightly larger than 64KB bios.bin which causes an error when Qemu tries to load it:

    qemu: could not load PC BIOS 'qboot/build/bios.bin'

This behavior change was introduced because the elf linker step was changed from using ld directly to using cc. Basically something like following Makefile change:

     bios.bin.elf: $(obj-y) flat.lds
    -        $(LD) -T flat.lds -o bios.bin.elf $(obj-y)
    +        $(CC) -o bios.bin.elf $(obj-y) -Wl,--no-undefined -Wl,--as-needed -nostdlib -m32 -Wl,--build-id=none -Wl,-Tflat.lds

GCC will then take care of calling ld with the appropriate arguments. And one of these arguments for the "--enable-default-pie" gcc is "-pie":

    $(LD) --build-id --eh-frame-hdr -m elf_i386 --hash-style=gnu -dynamic-linker /lib/ld-linux.so.2 -pie -o bios.bin.elf $(obj-y) --no-undefined --as-needed --build-id=none -Tflat.lds

This default behavior of gcc must be suppressed by adding -no-pie to the arguments when linking the object files.