### PR TITLE
Clear and disable interrupt before jumping to protected mode to compatible with intel 64 processor

### DIFF
--- a/cstart.S
+++ b/cstart.S
@@ -2,6 +2,7 @@
 #include "assembly.h"
 .section .init
 ENTRY(pm_entry)
+	cli
 	xor %ax, %ax
 	mov %ax, %ds
 	mov %ax, %es


### PR DESCRIPTION
To make it compatible with intel 64 processor, intel manual recommends that we disable and clear interrupt before jumping to protected mode by `cli` instruction